### PR TITLE
Rename contract & trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `laravel-ban` will be documented in this file.
 
+## 2.0.0 - 2017-03-06
+
+### Changed
+
+- Contract `CanBeBanned` renamed to `HasBans`
+- Trait `CanBeBanned` renamed to `HasBans`
+
 ## 1.0.0 - 2017-03-05
 
 - Initial release
+
+[2.0.0]: https://github.com/cybercog/laravel-ban/compare/1.0.0...2.0.0

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Use case is not limited to User model, any Eloquent model could be banned: Organ
 - Designed to work with Laravel Eloquent models.
 - Using contracts to keep high customization capabilities.
 - Using traits to get functionality out of the box.
+- Model can has many bans.
+- Removed bans keeps in history as Soft deleted record.
 - Most part of the the logic is handled by the `BanService`.
 - Has middleware to prevent banned user route access.
 - Use case is not limited to `User` model, any Eloquent model could be banned.
@@ -72,24 +74,25 @@ php artisan migrate
 ### Prepare bannable model
 
 ```php
-use Cog\Ban\Contracts\CanBeBanned as CanBeBannedContract;
-use Cog\Ban\Traits\CanBeBanned;
+use Cog\Ban\Contracts\HasBans as HasBansContract;
+use Cog\Ban\Traits\HasBans;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
-class User extends Authenticatable implements CanBeBannedContract
+class User extends Authenticatable implements HasBansContract
 {
-    use CanBeBanned;
+    use HasBans;
 }
 ```
 
-*Note: `CanBeBanned` contract using `CanBeOwner` contract under the hood. If you are using [`cybercog/laravel-ownership`](https://github.com/cybercog/laravel-ownership) package `CanBeOwner` contract could be omitted from bannable model.*
+*Note: `HasBans` contract using `CanBeOwner` contract under the hood. If you are using [`cybercog/laravel-ownership`](https://github.com/cybercog/laravel-ownership) package `CanBeOwner` contract could be omitted from bannable model.*
 
 ### Prepare bannable model database table
 
-Bannable model must have `nullable timestamp` column named `banned_at`. This value used as flag and simplify checks if user was banned. If you are trying to make default Laravel User model to be bannable you can use this example:
+Bannable model must have `nullable timestamp` column named `banned_at`. This value used as flag and simplify checks if user was banned. If you are trying to make default Laravel User model to be bannable you can use example below.
+
+Create migration file `2017_03_05_000001_add_banned_at_column_to_users_table.php`:
 
 ```php
-// 2017_03_05_000001_add_banned_at_column_to_users_table.php
 <?php
 
 use Illuminate\Database\Migrations\Migration;

--- a/src/Contracts/BanService.php
+++ b/src/Contracts/BanService.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Ban\Contracts;
 
-use Cog\Ban\Contracts\CanBeBanned as CanBeBannedContract;
+use Cog\Ban\Contracts\HasBans as HasBansContract;
 
 /**
  * Interface BanService.
@@ -23,19 +23,19 @@ interface BanService
     /**
      * Ban entity.
      *
-     * @param \Cog\Ban\Contracts\CanBeBanned $bannable
+     * @param \Cog\Ban\Contracts\HasBans $bannable
      * @param array $attributes
      * @return \Cog\Ban\Contracts\Ban
      */
-    public function ban(CanBeBannedContract $bannable, array $attributes = []);
+    public function ban(HasBansContract $bannable, array $attributes = []);
 
     /**
      * Unban entity.
      *
-     * @param \Cog\Ban\Contracts\CanBeBanned $bannable
+     * @param \Cog\Ban\Contracts\HasBans $bannable
      * @return void
      */
-    public function unban(CanBeBannedContract $bannable);
+    public function unban(HasBansContract $bannable);
 
     /**
      * Delete all expired Ban models.

--- a/src/Contracts/HasBans.php
+++ b/src/Contracts/HasBans.php
@@ -14,11 +14,11 @@ namespace Cog\Ban\Contracts;
 use Cog\Ownership\Contracts\CanBeOwner as CanBeOwnerContract;
 
 /**
- * Interface CanBeBanned.
+ * Interface HasBans.
  *
  * @package Cog\Ban\Contracts
  */
-interface CanBeBanned extends CanBeOwnerContract
+interface HasBans extends CanBeOwnerContract
 {
     /**
      * Entity Bans.

--- a/src/Events/ModelWasBanned.php
+++ b/src/Events/ModelWasBanned.php
@@ -12,7 +12,7 @@
 namespace Cog\Ban\Events;
 
 use Cog\Ban\Contracts\Ban as BanContract;
-use Cog\Ban\Contracts\CanBeBanned as CanBeBannedContract;
+use Cog\Ban\Contracts\HasBans as HasBansContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 /**
@@ -23,7 +23,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 class ModelWasBanned implements ShouldQueue
 {
     /**
-     * @var \Cog\Ban\Contracts\CanBeBanned
+     * @var \Cog\Ban\Contracts\HasBans
      */
     private $model;
 
@@ -33,10 +33,10 @@ class ModelWasBanned implements ShouldQueue
     private $ban;
 
     /**
-     * @param \Cog\Ban\Contracts\CanBeBanned $model
+     * @param \Cog\Ban\Contracts\HasBans $model
      * @param \Cog\Ban\Contracts\Ban $ban
      */
-    public function __construct(CanBeBannedContract $model, BanContract $ban)
+    public function __construct(HasBansContract $model, BanContract $ban)
     {
         $this->model = $model;
         $this->ban = $ban;

--- a/src/Events/ModelWasUnbanned.php
+++ b/src/Events/ModelWasUnbanned.php
@@ -11,7 +11,7 @@
 
 namespace Cog\Ban\Events;
 
-use Cog\Ban\Contracts\CanBeBanned as CanBeBannedContract;
+use Cog\Ban\Contracts\HasBans as HasBansContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
 /**
@@ -22,14 +22,14 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 class ModelWasUnbanned implements ShouldQueue
 {
     /**
-     * @var \Cog\Ban\Contracts\CanBeBanned
+     * @var \Cog\Ban\Contracts\HasBans
      */
     private $model;
 
     /**
-     * @param \Cog\Ban\Contracts\CanBeBanned $model
+     * @param \Cog\Ban\Contracts\HasBans $model
      */
-    public function __construct(CanBeBannedContract $model)
+    public function __construct(HasBansContract $model)
     {
         $this->model = $model;
     }

--- a/src/Services/BanService.php
+++ b/src/Services/BanService.php
@@ -13,7 +13,7 @@ namespace Cog\Ban\Services;
 
 use Carbon\Carbon;
 use Cog\Ban\Contracts\BanService as BanServiceContract;
-use Cog\Ban\Contracts\CanBeBanned;
+use Cog\Ban\Contracts\HasBans;
 use Cog\Ban\Models\Ban;
 
 /**
@@ -26,11 +26,11 @@ class BanService implements BanServiceContract
     /**
      * Ban entity.
      *
-     * @param \Cog\Ban\Contracts\CanBeBanned $bannable
+     * @param \Cog\Ban\Contracts\HasBans $bannable
      * @param array $attributes
      * @return \Cog\Ban\Contracts\Ban
      */
-    public function ban(CanBeBanned $bannable, array $attributes = [])
+    public function ban(HasBans $bannable, array $attributes = [])
     {
         return $bannable->bans()->create($attributes);
     }
@@ -38,10 +38,10 @@ class BanService implements BanServiceContract
     /**
      * Unban entity.
      *
-     * @param \Cog\Ban\Contracts\CanBeBanned $bannable
+     * @param \Cog\Ban\Contracts\HasBans $bannable
      * @return void
      */
-    public function unban(CanBeBanned $bannable)
+    public function unban(HasBans $bannable)
     {
         $bannable->bans->each(function ($ban) {
             $ban->delete();

--- a/src/Traits/HasBans.php
+++ b/src/Traits/HasBans.php
@@ -15,11 +15,11 @@ use Cog\Ban\Contracts\Ban as BanContract;
 use Cog\Ban\Contracts\BanService as BanServiceContract;
 
 /**
- * Class CanBeBanned.
+ * Class HasBans.
  *
  * @package Cog\Ban\Traits
  */
-trait CanBeBanned
+trait HasBans
 {
     use HasBannedAt;
 

--- a/tests/stubs/Models/User.php
+++ b/tests/stubs/Models/User.php
@@ -11,8 +11,8 @@
 
 namespace Cog\Ban\Tests\Stubs\Models;
 
-use Cog\Ban\Contracts\CanBeBanned as CanBeBannedContract;
-use Cog\Ban\Traits\CanBeBanned;
+use Cog\Ban\Contracts\HasBans as HasBansContract;
+use Cog\Ban\Traits\HasBans;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 /**
@@ -20,9 +20,9 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
  *
  * @package Cog\Ban\Tests\Stubs\Models
  */
-class User extends Authenticatable implements CanBeBannedContract
+class User extends Authenticatable implements HasBansContract
 {
-    use CanBeBanned;
+    use HasBans;
 
     /**
      * The table associated with the model.

--- a/tests/unit/Traits/HasBansTest.php
+++ b/tests/unit/Traits/HasBansTest.php
@@ -17,11 +17,11 @@ use Cog\Ban\Tests\Stubs\Models\User;
 use Cog\Ban\Tests\TestCase;
 
 /**
- * Class CanBeBannedTest.
+ * Class HasBansTest.
  *
  * @package Cog\Ban\Tests\Unit\Traits
  */
-class CanBeBannedTest extends TestCase
+class HasBansTest extends TestCase
 {
     /** @test */
     public function it_can_has_related_ban()


### PR DESCRIPTION
Contract & Trait renamed to follow CyberCog naming convention.

- Contract `CanBeBanned` renamed to `HasBans`
- Trait `CanBeBanned` renamed to `HasBans`