### PR TITLE
Add Laravel 5.5 dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,9 +37,9 @@
     "require": {
         "php": "^5.6|^7.0",
         "cybercog/laravel-ownership": "^3.0",
-        "illuminate/database": "~5.1.20|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/events": "~5.1.20|~5.2.0|~5.3.0|~5.4.0",
-        "illuminate/support": "~5.1.20|~5.2.0|~5.3.0|~5.4.0"
+        "illuminate/database": "~5.1.20|~5.2.0|~5.3.0|~5.4.0|5.5.*",
+        "illuminate/events": "~5.1.20|~5.2.0|~5.3.0|~5.4.0|5.5.*",
+        "illuminate/support": "~5.1.20|~5.2.0|~5.3.0|~5.4.0|5.5.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.11",


### PR DESCRIPTION
For some cases. Companies. Start long term development on the dev version of L5.5.