### PR TITLE
Remove $table from Ban model

### DIFF
--- a/src/Models/Ban.php
+++ b/src/Models/Ban.php
@@ -28,13 +28,6 @@ class Ban extends Model implements BanContract
     use SoftDeletes;
 
     /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'bans';
-
-    /**
      * The attributes that are mass assignable.
      *
      * @var array


### PR DESCRIPTION
this PR , removes $table property from Ban model , as by default laravel [convention](https://laravel.com/docs/5.6/eloquent#eloquent-model-conventions) will use "snake case", plural name of the class as the table name