### PR TITLE
force user to logout if he got banned ,

### DIFF
--- a/src/Http/Middleware/ForbidBannedUser.php
+++ b/src/Http/Middleware/ForbidBannedUser.php
@@ -49,7 +49,6 @@ class ForbidBannedUser
         $user = $this->auth->user();
 
         if ($user && $user->isBanned()) {
-            
             auth()->logout();
             return redirect()->back()->withInput()->withErrors([
                 'login' => 'This account is blocked.',

--- a/src/Http/Middleware/ForbidBannedUser.php
+++ b/src/Http/Middleware/ForbidBannedUser.php
@@ -49,7 +49,8 @@ class ForbidBannedUser
         $user = $this->auth->user();
 
         if ($user && $user->isBanned()) {
-            auth()->logout();
+            $this->auth->logout();
+
             return redirect()->back()->withInput()->withErrors([
                 'login' => 'This account is blocked.',
             ]);

--- a/src/Http/Middleware/ForbidBannedUser.php
+++ b/src/Http/Middleware/ForbidBannedUser.php
@@ -49,8 +49,8 @@ class ForbidBannedUser
         $user = $this->auth->user();
 
         if ($user && $user->isBanned()) {
-            auth()->logout();
             
+            auth()->logout();
             return redirect()->back()->withInput()->withErrors([
                 'login' => 'This account is blocked.',
             ]);

--- a/src/Http/Middleware/ForbidBannedUser.php
+++ b/src/Http/Middleware/ForbidBannedUser.php
@@ -50,6 +50,7 @@ class ForbidBannedUser
 
         if ($user && $user->isBanned()) {
             auth()->logout();
+            
             return redirect()->back()->withInput()->withErrors([
                 'login' => 'This account is blocked.',
             ]);

--- a/src/Http/Middleware/ForbidBannedUser.php
+++ b/src/Http/Middleware/ForbidBannedUser.php
@@ -49,6 +49,7 @@ class ForbidBannedUser
         $user = $this->auth->user();
 
         if ($user && $user->isBanned()) {
+            auth()->logout();
             return redirect()->back()->withInput()->withErrors([
                 'login' => 'This account is blocked.',
             ]);


### PR DESCRIPTION
in the previous implementation , it may case an infinite http loop, 
middleware will redirect to login page then login page will redirect again to dashboard because the user has login session and so on ,
 auth()->logout(); 
the issue will happen if shouldApplyBannedAtScope is false as what in my case 
 