### PR TITLE
Add `isPermanent` & `isTemporary` ban checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-ban` will be documented in this file.
 
+## [3.3.0] - 2018-09-16
+
+### Added
+
+- ([#27](https://github.com/cybercog/laravel-ban/pull/27)) Add `isPermanent` & `isTemporary` ban checks
+
 ## [3.2.0] - 2018-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to `laravel-ban` will be documented in this file.
 
 - ([#27](https://github.com/cybercog/laravel-ban/pull/27)) Add `isPermanent` & `isTemporary` ban checks
 
+### Fixed
+
+- ([#27](https://github.com/cybercog/laravel-ban/pull/27)) Stop trying to parse `null` value for `expired_at` as Carbon value
+
 ## [3.2.0] - 2018-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -195,6 +195,34 @@ $user->isNotBanned();
 app(\Cog\Contracts\Ban\BanService::class)->deleteExpiredBans();
 ```
 
+#### Determine if ban is permanent
+
+```php
+$ban = $user->ban();
+
+$ban->isPermanent(); // true
+```
+
+Or pass `null` value.
+
+```php
+$ban = $user->ban([
+   'expired_at' => null,
+]);
+
+$ban->isPermanent(); // true
+```
+
+#### Determine if ban is temporary
+
+```php
+$ban = $user->ban([
+   'expired_at' => '2086-03-28 00:00:00',
+]);
+
+$ban->isTemporary(); // true
+```
+
 ### Scopes
 
 #### Get all models which are not banned

--- a/contracts/Ban.php
+++ b/contracts/Ban.php
@@ -11,9 +11,6 @@
 
 namespace Cog\Contracts\Ban;
 
-use Cog\Contracts\Ban\Bannable as BannableContract;
-use Illuminate\Database\Eloquent\Builder;
-
 /**
  * Interface Ban.
  *
@@ -36,11 +33,16 @@ interface Ban
     public function bannable();
 
     /**
-     * Scope a query to only include bans by bannable model.
+     * Determine if Ban is permanent.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param \Cog\Contracts\Ban\Bannable $bannable
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return bool
      */
-    public function scopeWhereBannable(Builder $query, BannableContract $bannable);
+    public function isPermanent();
+
+    /**
+     * Determine if Ban is temporary.
+     *
+     * @return bool
+     */
+    public function isTemporary();
 }

--- a/src/Models/Ban.php
+++ b/src/Models/Ban.php
@@ -61,11 +61,7 @@ class Ban extends Model implements BanContract
      */
     public function setExpiredAtAttribute($value)
     {
-        if (is_null($value)) {
-            return;
-        }
-
-        if (!$value instanceof Carbon) {
+        if (!is_null($value) && !$value instanceof Carbon) {
             $value = Carbon::parse($value);
         }
 

--- a/src/Models/Ban.php
+++ b/src/Models/Ban.php
@@ -57,9 +57,14 @@ class Ban extends Model implements BanContract
      * Expired timestamp mutator.
      *
      * @param \Carbon\Carbon|string $value
+     * @return void
      */
     public function setExpiredAtAttribute($value)
     {
+        if (is_null($value)) {
+            return;
+        }
+
         if (!$value instanceof Carbon) {
             $value = Carbon::parse($value);
         }

--- a/src/Models/Ban.php
+++ b/src/Models/Ban.php
@@ -68,6 +68,26 @@ class Ban extends Model implements BanContract
     }
 
     /**
+     * Determine if Ban is permanent.
+     *
+     * @return bool
+     */
+    public function isPermanent()
+    {
+        return !isset($this->attributes['expired_at']) || is_null($this->attributes['expired_at']);
+    }
+
+    /**
+     * Determine if Ban is temporary.
+     *
+     * @return bool
+     */
+    public function isTemporary()
+    {
+        return !$this->isPermanent();
+    }
+
+    /**
      * Entity responsible for ban.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
@@ -97,8 +117,8 @@ class Ban extends Model implements BanContract
     public function scopeWhereBannable(Builder $query, BannableContract $bannable)
     {
         return $query->where([
-            'bannable_id' => $bannable->getKey(),
             'bannable_type' => $bannable->getMorphClass(),
+            'bannable_id' => $bannable->getKey(),
         ]);
     }
 }

--- a/tests/Unit/Models/BanTest.php
+++ b/tests/Unit/Models/BanTest.php
@@ -58,6 +58,16 @@ class BanTest extends TestCase
     }
 
     /** @test */
+    public function it_not_modify_null_expired_at()
+    {
+        $ban = new Ban([
+            'expired_at' => null,
+        ]);
+
+        $this->assertNull($ban->expired_at);
+    }
+
+    /** @test */
     public function it_can_has_ban_creator()
     {
         $bannedBy = factory(User::class)->create();
@@ -157,5 +167,16 @@ class BanTest extends TestCase
 
         $this->assertFalse($permanentBan->isTemporary());
         $this->assertTrue($temporaryBan->isTemporary());
+    }
+
+    /** @test */
+    public function it_can_check_if_ban_with_null_expired_at_is_permanent()
+    {
+        $permanentBan = new Ban([
+            'expired_at' => null,
+        ]);
+
+        $this->assertTrue($permanentBan->isPermanent());
+        $this->assertFalse($permanentBan->isTemporary());
     }
 }

--- a/tests/Unit/Models/BanTest.php
+++ b/tests/Unit/Models/BanTest.php
@@ -134,4 +134,28 @@ class BanTest extends TestCase
 
         $this->assertCount(4, $bannableModels);
     }
+
+    /** @test */
+    public function it_can_check_if_ban_is_permanent()
+    {
+        $permanentBan = new Ban();
+        $temporaryBan = new Ban([
+            'expired_at' => '2086-03-28 00:00:00',
+        ]);
+
+        $this->assertTrue($permanentBan->isPermanent());
+        $this->assertFalse($temporaryBan->isPermanent());
+    }
+
+    /** @test */
+    public function it_can_check_if_ban_is_temporary()
+    {
+        $permanentBan = new Ban();
+        $temporaryBan = new Ban([
+            'expired_at' => '2086-03-28 00:00:00',
+        ]);
+
+        $this->assertFalse($permanentBan->isTemporary());
+        $this->assertTrue($temporaryBan->isTemporary());
+    }
 }


### PR DESCRIPTION
This PR introduces determination if ban is permanent or temporary. And fixes broken logic when `null` value of `expired_at` attribute treated as parseable Carbon value.

Temporary bans has filled `expired_at` datetime attribute:

```php
$temporaryBan = $user->bans()->create([
    'expired_at' => '2086-03-28 00:00:00',
]);
$temporaryBan->isTemporary(); // true
```

Permanent bans don't has filled `expired_at` datetime attribute or this value equal to `null`:

```php
$anotherPermanentBan = $user->bans()->create();
$anotherPermanentBan->isPermanent(); // true

$permanentBan = $user->bans()->create([
    'expired_at' => null,
]);
$permanentBan->isPermanent(); // true
```