### PR TITLE
Added a cast for the deleted_at field

### DIFF
--- a/src/Models/Ban.php
+++ b/src/Models/Ban.php
@@ -51,6 +51,7 @@ class Ban extends Model implements BanContract
      */
     protected $casts = [
         'expired_at' => 'datetime',
+        'deleted_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
When creating a resource for the `bans` table, the `deleted_at` column needs to be cast to a `datetime` object. Without it, filtering deleted bans in the bannable's `MorphMany` relationship causes an error.