### PR TITLE
Deleted lines which make testing impossible

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,1 @@
 * text=auto
-
-/tests export-ignore
-/.gitattributes export-ignore
-/.gitignore export-ignore
-/.php_cs export-ignore
-/.styleci.yml export-ignore
-/.travis.yml export-ignore
-/CODE_OF_CONDUCT.md export-ignore
-/CONTRIBUTING.md export-ignore
-/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Like the flux capacitor and time travel, testing equipment is what makes tests possible!

To allow for easy contributing, I've altered the `.gitattributes` file to stop blocking access to testing equipment. I'm planning a second PR with a bug fix, and was originally shocked to see that there weren't any tests, but alas, they were just hidden.