### PR TITLE
Make Ban created_by_type & created_by_id fillable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-ban` will be documented in this file.
 
+## [3.5.0] - 2018-10-07
+
+### Added
+
+- ([#35](https://github.com/cybercog/laravel-ban/pull/35)) Ban `created_by_type` & `created_by_id` are fillable now
+
 ## [3.4.0] - 2018-09-21
 
 ### Added
@@ -90,6 +96,7 @@ All notable changes to `laravel-ban` will be documented in this file.
 
 - Initial release
 
+[3.5.0]: https://github.com/cybercog/laravel-ban/compare/3.4.0...3.5.0
 [3.4.0]: https://github.com/cybercog/laravel-ban/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/cybercog/laravel-ban/compare/3.2.0...3.3.0
 [3.2.0]: https://github.com/cybercog/laravel-ban/compare/3.1.0...3.2.0

--- a/src/Models/Ban.php
+++ b/src/Models/Ban.php
@@ -42,6 +42,8 @@ class Ban extends Model implements BanContract
     protected $fillable = [
         'comment',
         'expired_at',
+        'created_by_type',
+        'created_by_id',
     ];
 
     /**

--- a/src/Observers/BanObserver.php
+++ b/src/Observers/BanObserver.php
@@ -31,10 +31,10 @@ class BanObserver
     public function creating(BanContract $ban)
     {
         $bannedBy = auth()->user();
-        if ($bannedBy) {
-            $ban->forceFill([
-                'created_by_id' => $bannedBy->getKey(),
+        if ($bannedBy && is_null($ban->created_by_type) && is_null($ban->created_by_id)) {
+            $ban->fill([
                 'created_by_type' => $bannedBy->getMorphClass(),
+                'created_by_id' => $bannedBy->getKey(),
             ]);
         }
     }

--- a/tests/Unit/Models/BanTest.php
+++ b/tests/Unit/Models/BanTest.php
@@ -30,7 +30,7 @@ class BanTest extends TestCase
             'comment' => 'Enjoy your ban!',
         ]);
 
-        $this->assertEquals('Enjoy your ban!', $ban->comment);
+        $this->assertSame('Enjoy your ban!', $ban->comment);
     }
 
     /** @test */
@@ -43,6 +43,26 @@ class BanTest extends TestCase
         ]);
 
         $this->assertEquals($expiredAt, $ban->expired_at);
+    }
+
+    /** @test */
+    public function it_can_fill_created_by_type()
+    {
+        $ban = new Ban([
+            'created_by_type' => 'TestType',
+        ]);
+
+        $this->assertSame('TestType', $ban->created_by_type);
+    }
+
+    /** @test */
+    public function it_can_fill_created_by_id()
+    {
+        $ban = new Ban([
+            'created_by_id' => '4',
+        ]);
+
+        $this->assertSame('4', $ban->created_by_id);
     }
 
     /** @test */
@@ -81,11 +101,42 @@ class BanTest extends TestCase
         $bannedBy = factory(User::class)->create();
 
         $ban = factory(Ban::class)->create([
-            'created_by_id' => $bannedBy->getKey(),
             'created_by_type' => $bannedBy->getMorphClass(),
+            'created_by_id' => $bannedBy->getKey(),
         ]);
 
         $this->assertInstanceOf(User::class, $ban->createdBy);
+    }
+
+    /** @test */
+    public function it_can_set_custom_ban_creator()
+    {
+        $bannable = factory(User::class)->create();
+        $bannedBy = factory(User::class)->create();
+
+        $ban = $bannable->bans()->create([
+            'created_by_type' => $bannedBy->getMorphClass(),
+            'created_by_id' => $bannedBy->getKey(),
+        ]);
+
+        $this->assertTrue($ban->createdBy->is($bannedBy));
+    }
+
+    /** @test */
+    public function it_not_overwrite_ban_creator_with_auth_user_if_custom_value_is_provided()
+    {
+        $bannable = factory(User::class)->create();
+        $bannedBy = factory(User::class)->create();
+        $currentUser = factory(User::class)->create();
+
+        $this->actingAs($currentUser);
+
+        $ban = $bannable->bans()->create([
+            'created_by_type' => $bannedBy->getMorphClass(),
+            'created_by_id' => $bannedBy->getKey(),
+        ]);
+
+        $this->assertTrue($ban->createdBy->is($bannedBy));
     }
 
     /** @test */


### PR DESCRIPTION
This [feature was requested](https://github.com/cybercog/laravel-ban/issues/23#issuecomment-427620808) by @irazasyed