### PR TITLE
Release v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: php
 
-sudo: false
-
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `laravel-ban` will be documented in this file.
 
+## [4.0.0] - 2019-02-26
+
+### Added
+
+- Laravel 5.8 support
+
+### Changed
+
+- All methods are strict typed now
+
+### Removed
+
+- Laravel 5.1, 5.2, 5.3 and 5.4 support
+
 ## [3.5.0] - 2018-10-07
 
 ### Added
@@ -96,6 +110,7 @@ All notable changes to `laravel-ban` will be documented in this file.
 
 - Initial release
 
+[4.0.0]: https://github.com/cybercog/laravel-ban/compare/3.5.0...v4.0.0
 [3.5.0]: https://github.com/cybercog/laravel-ban/compare/3.4.0...3.5.0
 [3.4.0]: https://github.com/cybercog/laravel-ban/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/cybercog/laravel-ban/compare/3.2.0...3.3.0

--- a/composer.json
+++ b/composer.json
@@ -35,17 +35,17 @@
         "docs": "https://github.com/cybercog/laravel-ban/wiki"
     },
     "require": {
-        "php": "^5.6|^7.0",
-        "illuminate/database": "~5.1.20|~5.2|~5.3|~5.4|~5.5|~5.6|~5.7",
-        "illuminate/events": "~5.1.20|~5.2|~5.3|~5.4|~5.5|~5.6|~5.7",
-        "illuminate/support": "~5.1.20|~5.2|~5.3|~5.4|~5.5|~5.6|~5.7"
+        "php": "^7.1.3",
+        "illuminate/database": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/events": "5.5.*|5.6.*|5.7.*|5.8.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
-        "orchestra/database": "~3.4.0|~3.5.0|~3.6.0|~3.7.0",
-        "orchestra/testbench": "~3.4.0|~3.5.0|~3.6.0|~3.7.0",
-        "phpunit/phpunit": "^5.7|^6.0|^7.0"
+        "orchestra/database": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|~3.8.0",
+        "phpunit/phpunit": "^7.5"
     },
     "autoload": {
         "psr-4": {

--- a/contracts/Ban.php
+++ b/contracts/Ban.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of Laravel Ban.
+ * This file is part of PHP Contracts: Ban.
  *
  * (c) Anton Komarev <a.komarev@cybercog.su>
  *
@@ -9,40 +9,23 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Contracts\Ban;
 
-/**
- * Interface Ban.
- *
- * @package Cog\Contracts\Ban
- */
 interface Ban
 {
-    /**
-     * Entity responsible for ban.
-     *
-     * @return mixed
-     */
-    public function createdBy();
-
-    /**
-     * Bannable model.
-     *
-     * @return \Cog\Contracts\Ban\Bannable
-     */
-    public function bannable();
-
     /**
      * Determine if Ban is permanent.
      *
      * @return bool
      */
-    public function isPermanent();
+    public function isPermanent(): bool;
 
     /**
      * Determine if Ban is temporary.
      *
      * @return bool
      */
-    public function isTemporary();
+    public function isTemporary(): bool;
 }

--- a/contracts/BanService.php
+++ b/contracts/BanService.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of Laravel Ban.
+ * This file is part of PHP Contracts: Ban.
  *
  * (c) Anton Komarev <a.komarev@cybercog.su>
  *
@@ -9,15 +9,10 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Contracts\Ban;
 
-use Cog\Contracts\Ban\Bannable as BannableContract;
-
-/**
- * Interface BanService.
- *
- * @package Cog\Contracts\Ban
- */
 interface BanService
 {
     /**
@@ -27,7 +22,7 @@ interface BanService
      * @param array $attributes
      * @return \Cog\Contracts\Ban\Ban
      */
-    public function ban(BannableContract $bannable, array $attributes = []);
+    public function ban(Bannable $bannable, array $attributes = []): Ban;
 
     /**
      * Unban entity.
@@ -35,12 +30,12 @@ interface BanService
      * @param \Cog\Contracts\Ban\Bannable $bannable
      * @return void
      */
-    public function unban(BannableContract $bannable);
+    public function unban(Bannable $bannable): void;
 
     /**
      * Delete all expired Ban models.
      *
      * @return void
      */
-    public function deleteExpiredBans();
+    public function deleteExpiredBans(): void;
 }

--- a/contracts/Bannable.php
+++ b/contracts/Bannable.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * This file is part of Laravel Ban.
+ * This file is part of PHP Contracts: Ban.
  *
  * (c) Anton Komarev <a.komarev@cybercog.su>
  *
@@ -9,76 +9,38 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Contracts\Ban;
 
-/**
- * Interface Bannable.
- *
- * @package Cog\Contracts\Ban
- */
 interface Bannable
 {
-    /**
-     * Get the value of the model's primary key.
-     *
-     * @return mixed
-     */
-    public function getKey();
-
-    /**
-     * Get the class name for polymorphic relations.
-     *
-     * @return string
-     */
-    public function getMorphClass();
-
-    /**
-     * Entity Bans.
-     *
-     * @return mixed
-     */
-    public function bans();
-
-    /**
-     * Set banned flag.
-     *
-     * @return $this
-     */
-    public function setBannedFlag();
-
-    /**
-     * Unset banned flag.
-     *
-     * @return $this
-     */
-    public function unsetBannedFlag();
-
     /**
      * Ban model.
      *
      * @param null|array $attributes
      * @return \Cog\Contracts\Ban\Ban
      */
-    public function ban(array $attributes = []);
+    public function ban(array $attributes = []): Ban;
 
     /**
      * Remove ban from model.
      *
      * @return void
      */
-    public function unban();
+    public function unban(): void;
 
     /**
      * If model is banned.
      *
      * @return bool
      */
-    public function isBanned();
+    public function isBanned(): bool;
 
     /**
      * If model is not banned.
      *
      * @return bool
      */
-    public function isNotBanned();
+    public function isNotBanned(): bool;
 }

--- a/database/migrations/2017_03_04_000000_create_bans_table.php
+++ b/database/migrations/2017_03_04_000000_create_bans_table.php
@@ -9,13 +9,12 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * Class CreateBansTable.
- */
 class CreateBansTable extends Migration
 {
     /**
@@ -23,7 +22,7 @@ class CreateBansTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('bans', function (Blueprint $table) {
             $table->increments('id');
@@ -43,7 +42,7 @@ class CreateBansTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('bans');
     }

--- a/src/Console/Commands/DeleteExpiredBans.php
+++ b/src/Console/Commands/DeleteExpiredBans.php
@@ -9,16 +9,13 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Console\Commands;
 
 use Cog\Laravel\Ban\Services\BanService;
 use Illuminate\Console\Command;
 
-/**
- * Class DeleteExpiredBans.
- *
- * @package Cog\Laravel\Ban\Console\Commands
- */
 class DeleteExpiredBans extends Command
 {
     /**
@@ -47,7 +44,7 @@ class DeleteExpiredBans extends Command
      *
      * @return void
      */
-    public function handle()
+    public function handle(): void
     {
         $this->service = app(BanService::class);
 

--- a/src/Events/ModelWasBanned.php
+++ b/src/Events/ModelWasBanned.php
@@ -9,17 +9,14 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Events;
 
 use Cog\Contracts\Ban\Ban as BanContract;
 use Cog\Contracts\Ban\Bannable as BannableContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-/**
- * Class ModelWasBanned.
- *
- * @package Cog\Laravel\Ban\Events
- */
 class ModelWasBanned implements ShouldQueue
 {
     /**

--- a/src/Events/ModelWasUnbanned.php
+++ b/src/Events/ModelWasUnbanned.php
@@ -9,16 +9,13 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Events;
 
 use Cog\Contracts\Ban\Bannable as BannableContract;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-/**
- * Class ModelWasUnbanned.
- *
- * @package Cog\Laravel\Ban\Events
- */
 class ModelWasUnbanned implements ShouldQueue
 {
     /**

--- a/src/Http/Middleware/ForbidBannedUser.php
+++ b/src/Http/Middleware/ForbidBannedUser.php
@@ -9,17 +9,14 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Http\Middleware;
 
 use Closure;
 use Cog\Contracts\Ban\Bannable as BannableContract;
 use Illuminate\Contracts\Auth\Guard;
 
-/**
- * Class ForbidBannedUser.
- *
- * @package Cog\Laravel\Ban\Http\Middleware
- */
 class ForbidBannedUser
 {
     /**

--- a/src/Http/Middleware/LogsOutBannedUser.php
+++ b/src/Http/Middleware/LogsOutBannedUser.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Http\Middleware;
 
 use Closure;
@@ -16,11 +18,6 @@ use Cog\Contracts\Ban\Bannable as BannableContract;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\StatefulGuard as StatefulGuardContract;
 
-/**
- * Class LogsOutBannedUser.
- *
- * @package Cog\Laravel\Ban\Http\Middleware
- */
 class LogsOutBannedUser
 {
     /**

--- a/src/Models/Ban.php
+++ b/src/Models/Ban.php
@@ -9,20 +9,18 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Models;
 
-use Carbon\Carbon;
 use Cog\Contracts\Ban\Ban as BanContract;
 use Cog\Contracts\Ban\Bannable as BannableContract;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
-/**
- * Class Ban.
- *
- * @package Cog\Laravel\Ban\Models
- */
 class Ban extends Model implements BanContract
 {
     use SoftDeletes;
@@ -59,10 +57,10 @@ class Ban extends Model implements BanContract
     /**
      * Expired timestamp mutator.
      *
-     * @param \Carbon\Carbon|string $value
+     * @param \Illuminate\Support\Carbon|string $value
      * @return void
      */
-    public function setExpiredAtAttribute($value)
+    public function setExpiredAtAttribute($value): void
     {
         if (!is_null($value) && !$value instanceof Carbon) {
             $value = Carbon::parse($value);
@@ -72,31 +70,11 @@ class Ban extends Model implements BanContract
     }
 
     /**
-     * Determine if Ban is permanent.
-     *
-     * @return bool
-     */
-    public function isPermanent()
-    {
-        return !isset($this->attributes['expired_at']) || is_null($this->attributes['expired_at']);
-    }
-
-    /**
-     * Determine if Ban is temporary.
-     *
-     * @return bool
-     */
-    public function isTemporary()
-    {
-        return !$this->isPermanent();
-    }
-
-    /**
      * Entity responsible for ban.
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function createdBy()
+    public function createdBy(): MorphTo
     {
         return $this->morphTo('created_by');
     }
@@ -106,9 +84,29 @@ class Ban extends Model implements BanContract
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphTo
      */
-    public function bannable()
+    public function bannable(): MorphTo
     {
         return $this->morphTo('bannable');
+    }
+
+    /**
+     * Determine if Ban is permanent.
+     *
+     * @return bool
+     */
+    public function isPermanent(): bool
+    {
+        return !isset($this->attributes['expired_at']) || is_null($this->attributes['expired_at']);
+    }
+
+    /**
+     * Determine if Ban is temporary.
+     *
+     * @return bool
+     */
+    public function isTemporary(): bool
+    {
+        return !$this->isPermanent();
     }
 
     /**
@@ -118,7 +116,7 @@ class Ban extends Model implements BanContract
      * @param \Cog\Contracts\Ban\Bannable $bannable
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function scopeWhereBannable(Builder $query, BannableContract $bannable)
+    public function scopeWhereBannable(Builder $query, BannableContract $bannable): Builder
     {
         return $query->where([
             'bannable_type' => $bannable->getMorphClass(),

--- a/src/Observers/BanObserver.php
+++ b/src/Observers/BanObserver.php
@@ -9,17 +9,14 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Observers;
 
 use Cog\Contracts\Ban\Ban as BanContract;
 use Cog\Laravel\Ban\Events\ModelWasBanned;
 use Cog\Laravel\Ban\Events\ModelWasUnbanned;
 
-/**
- * Class BanObserver.
- *
- * @package Cog\Laravel\Ban\Observers
- */
 class BanObserver
 {
     /**
@@ -28,7 +25,7 @@ class BanObserver
      * @param \Cog\Contracts\Ban\Ban $ban
      * @return void
      */
-    public function creating(BanContract $ban)
+    public function creating(BanContract $ban): void
     {
         $bannedBy = auth()->user();
         if ($bannedBy && is_null($ban->created_by_type) && is_null($ban->created_by_id)) {
@@ -45,7 +42,7 @@ class BanObserver
      * @param \Cog\Contracts\Ban\Ban $ban
      * @return void
      */
-    public function created(BanContract $ban)
+    public function created(BanContract $ban): void
     {
         $bannable = $ban->bannable()->withBanned()->first();
         $bannable->setBannedFlag($ban->created_at)->save();
@@ -59,7 +56,7 @@ class BanObserver
      * @param \Cog\Contracts\Ban\Ban $ban
      * @return void
      */
-    public function deleted(BanContract $ban)
+    public function deleted(BanContract $ban): void
     {
         $bannable = $ban->bannable()->withBanned()->first();
         if ($bannable->bans->count() === 0) {

--- a/src/Providers/BanServiceProvider.php
+++ b/src/Providers/BanServiceProvider.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Providers;
 
 use Cog\Laravel\Ban\Console\Commands\DeleteExpiredBans;
@@ -19,33 +21,30 @@ use Cog\Laravel\Ban\Observers\BanObserver;
 use Cog\Laravel\Ban\Services\BanService;
 use Illuminate\Support\ServiceProvider;
 
-/**
- * Class BanServiceProvider.
- *
- * @package Cog\Laravel\Ban\Providers
- */
 class BanServiceProvider extends ServiceProvider
 {
-    /**
-     * Perform post-registration booting of services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        $this->registerPublishes();
-        $this->registerObservers();
-    }
-
     /**
      * Register bindings in the container.
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->registerContracts();
         $this->registerConsoleCommands();
+    }
+
+    /**
+     * Perform post-registration booting of services.
+     *
+     * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function boot(): void
+    {
+        $this->registerPublishes();
+        $this->registerObservers();
     }
 
     /**
@@ -53,7 +52,7 @@ class BanServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerConsoleCommands()
+    protected function registerConsoleCommands(): void
     {
         if ($this->app->runningInConsole()) {
             $this->app->bind('command.ban:delete-expired', DeleteExpiredBans::class);
@@ -69,7 +68,7 @@ class BanServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerContracts()
+    protected function registerContracts(): void
     {
         $this->app->bind(BanContract::class, Ban::class);
         $this->app->singleton(BanServiceContract::class, BanService::class);
@@ -79,8 +78,10 @@ class BanServiceProvider extends ServiceProvider
      * Register Ban's models observers.
      *
      * @return void
+     *
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    protected function registerObservers()
+    protected function registerObservers(): void
     {
         $this->app->make(BanContract::class)->observe(new BanObserver);
     }
@@ -90,7 +91,7 @@ class BanServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    protected function registerPublishes()
+    protected function registerPublishes(): void
     {
         if ($this->app->runningInConsole()) {
             $migrationsPath = __DIR__ . '/../../database/migrations';

--- a/src/Scopes/BannedAtScope.php
+++ b/src/Scopes/BannedAtScope.php
@@ -9,17 +9,14 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Scopes;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
 
-/**
- * Class BannedAtScope.
- *
- * @package Cog\Laravel\Ban\Scopes
- */
 class BannedAtScope implements Scope
 {
     /**
@@ -55,7 +52,7 @@ class BannedAtScope implements Scope
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    public function extend(Builder $builder)
+    public function extend(Builder $builder): void
     {
         foreach ($this->extensions as $extension) {
             $this->{"add{$extension}"}($builder);
@@ -68,7 +65,7 @@ class BannedAtScope implements Scope
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithBanned(Builder $builder)
+    protected function addWithBanned(Builder $builder): void
     {
         $builder->macro('withBanned', function (Builder $builder) {
             return $builder->withoutGlobalScope($this);
@@ -81,7 +78,7 @@ class BannedAtScope implements Scope
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addWithoutBanned(Builder $builder)
+    protected function addWithoutBanned(Builder $builder): void
     {
         $builder->macro('withoutBanned', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->whereNull('banned_at');
@@ -94,7 +91,7 @@ class BannedAtScope implements Scope
      * @param \Illuminate\Database\Eloquent\Builder $builder
      * @return void
      */
-    protected function addOnlyBanned(Builder $builder)
+    protected function addOnlyBanned(Builder $builder): void
     {
         $builder->macro('onlyBanned', function (Builder $builder) {
             return $builder->withoutGlobalScope($this)->whereNotNull('banned_at');

--- a/src/Services/BanService.php
+++ b/src/Services/BanService.php
@@ -9,18 +9,16 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Services;
 
-use Carbon\Carbon;
-use Cog\Contracts\Ban\Bannable;
+use Cog\Contracts\Ban\Ban as BanContract;
+use Cog\Contracts\Ban\Bannable as BannableContract;
 use Cog\Contracts\Ban\BanService as BanServiceContract;
 use Cog\Laravel\Ban\Models\Ban;
+use Illuminate\Support\Carbon;
 
-/**
- * Class BanService.
- *
- * @package Cog\Laravel\Ban\Services
- */
 class BanService implements BanServiceContract
 {
     /**
@@ -30,7 +28,7 @@ class BanService implements BanServiceContract
      * @param array $attributes
      * @return \Cog\Contracts\Ban\Ban
      */
-    public function ban(Bannable $bannable, array $attributes = [])
+    public function ban(BannableContract $bannable, array $attributes = []): BanContract
     {
         return $bannable->bans()->create($attributes);
     }
@@ -41,7 +39,7 @@ class BanService implements BanServiceContract
      * @param \Cog\Contracts\Ban\Bannable $bannable
      * @return void
      */
-    public function unban(Bannable $bannable)
+    public function unban(BannableContract $bannable): void
     {
         $bannable->bans->each(function ($ban) {
             $ban->delete();
@@ -53,9 +51,11 @@ class BanService implements BanServiceContract
      *
      * @return void
      */
-    public function deleteExpiredBans()
+    public function deleteExpiredBans(): void
     {
-        $bans = Ban::where('expired_at', '<=', Carbon::now()->format('Y-m-d H:i:s'))->get();
+        $bans = Ban::query()
+            ->where('expired_at', '<=', Carbon::now()->format('Y-m-d H:i:s'))
+            ->get();
 
         $bans->each(function ($ban) {
             $ban->delete();

--- a/src/Traits/Bannable.php
+++ b/src/Traits/Bannable.php
@@ -9,13 +9,10 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Traits;
 
-/**
- * Trait Bannable.
- *
- * @package Cog\Laravel\Ban\Traits
- */
 trait Bannable
 {
     use HasBannedAtHelpers;

--- a/src/Traits/HasBannedAtHelpers.php
+++ b/src/Traits/HasBannedAtHelpers.php
@@ -9,16 +9,14 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Traits;
 
-use Carbon\Carbon;
+use Cog\Contracts\Ban\Ban as BanContract;
 use Cog\Contracts\Ban\BanService as BanServiceContract;
+use Illuminate\Support\Carbon;
 
-/**
- * Trait HasBannedAtHelpers.
- *
- * @package Cog\Laravel\Ban\Traits
- */
 trait HasBannedAtHelpers
 {
     /**
@@ -28,7 +26,7 @@ trait HasBannedAtHelpers
      */
     public function setBannedFlag()
     {
-        $this->banned_at = Carbon::now();
+        $this->setAttribute('banned_at', Carbon::now());
 
         return $this;
     }
@@ -40,7 +38,7 @@ trait HasBannedAtHelpers
      */
     public function unsetBannedFlag()
     {
-        $this->banned_at = null;
+        $this->setAttribute('banned_at', null);
 
         return $this;
     }
@@ -50,9 +48,9 @@ trait HasBannedAtHelpers
      *
      * @return bool
      */
-    public function isBanned()
+    public function isBanned(): bool
     {
-        return $this->banned_at !== null;
+        return $this->getAttributeValue('banned_at') !== null;
     }
 
     /**
@@ -60,7 +58,7 @@ trait HasBannedAtHelpers
      *
      * @return bool
      */
-    public function isNotBanned()
+    public function isNotBanned(): bool
     {
         return !$this->isBanned();
     }
@@ -71,7 +69,7 @@ trait HasBannedAtHelpers
      * @param null|array $attributes
      * @return \Cog\Contracts\Ban\Ban
      */
-    public function ban(array $attributes = [])
+    public function ban(array $attributes = []): BanContract
     {
         return app(BanServiceContract::class)->ban($this, $attributes);
     }
@@ -81,7 +79,7 @@ trait HasBannedAtHelpers
      *
      * @return void
      */
-    public function unban()
+    public function unban(): void
     {
         app(BanServiceContract::class)->unban($this);
     }

--- a/src/Traits/HasBannedAtScope.php
+++ b/src/Traits/HasBannedAtScope.php
@@ -9,15 +9,12 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Traits;
 
 use Cog\Laravel\Ban\Scopes\BannedAtScope;
 
-/**
- * Trait HasBannedAtScope.
- *
- * @package Cog\Laravel\Ban\Traits
- */
 trait HasBannedAtScope
 {
     /**
@@ -25,8 +22,8 @@ trait HasBannedAtScope
      *
      * @return void
      */
-    public static function bootHasBannedAtScope()
+    public static function bootHasBannedAtScope(): void
     {
-        static::addGlobalScope(new BannedAtScope);
+        static::addGlobalScope(new BannedAtScope());
     }
 }

--- a/src/Traits/HasBansRelation.php
+++ b/src/Traits/HasBansRelation.php
@@ -9,15 +9,13 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Laravel\Ban\Traits;
 
 use Cog\Contracts\Ban\Ban as BanContract;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 
-/**
- * Trait HasBansRelation.
- *
- * @package Cog\Laravel\Ban\Traits
- */
 trait HasBansRelation
 {
     /**
@@ -25,7 +23,7 @@ trait HasBansRelation
      *
      * @return \Illuminate\Database\Eloquent\Relations\MorphMany
      */
-    public function bans()
+    public function bans(): MorphMany
     {
         return $this->morphMany(app(BanContract::class), 'bannable');
     }

--- a/tests/Stubs/Models/User.php
+++ b/tests/Stubs/Models/User.php
@@ -9,17 +9,14 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Stubs\Models;
 
 use Cog\Contracts\Ban\Bannable as BannableContract;
 use Cog\Laravel\Ban\Traits\Bannable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
-/**
- * Class User.
- *
- * @package Cog\Tests\Laravel\Ban\Stubs\Models
- */
 class User extends Authenticatable implements BannableContract
 {
     use Bannable;

--- a/tests/Stubs/Models/UserWithBannedAtScopeApplied.php
+++ b/tests/Stubs/Models/UserWithBannedAtScopeApplied.php
@@ -9,13 +9,10 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Stubs\Models;
 
-/**
- * Class UserWithBannedAtScopeApplied.
- *
- * @package Cog\Tests\Laravel\Ban\Stubs\Models
- */
 class UserWithBannedAtScopeApplied extends User
 {
     /**
@@ -23,7 +20,7 @@ class UserWithBannedAtScopeApplied extends User
      *
      * @return bool
      */
-    public function shouldApplyBannedAtScope()
+    public function shouldApplyBannedAtScope(): bool
     {
         return true;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,17 +9,16 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban;
 
+use Cog\Laravel\Ban\Providers\BanServiceProvider;
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Illuminate\Support\Facades\File;
+use Orchestra\Database\ConsoleServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
-/**
- * Class TestCase.
- *
- * @package Cog\Tests\Laravel\Ban
- */
 abstract class TestCase extends Orchestra
 {
     /**
@@ -27,7 +26,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -44,7 +43,7 @@ abstract class TestCase extends Orchestra
      * @param \Illuminate\Foundation\Application $app
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
         $this->setDefaultUserModel($app);
     }
@@ -55,11 +54,11 @@ abstract class TestCase extends Orchestra
      * @param \Illuminate\Foundation\Application $app
      * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
-            \Cog\Laravel\Ban\Providers\BanServiceProvider::class,
-            \Orchestra\Database\ConsoleServiceProvider::class,
+            BanServiceProvider::class,
+            ConsoleServiceProvider::class,
         ];
     }
 
@@ -68,7 +67,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function publishPackageMigrations()
+    protected function publishPackageMigrations(): void
     {
         $this->artisan('vendor:publish', [
             '--force' => '',
@@ -81,7 +80,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function destroyPackageMigrations()
+    protected function destroyPackageMigrations(): void
     {
         File::cleanDirectory('vendor/orchestra/testbench-core/laravel/database/migrations');
     }
@@ -91,7 +90,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function migrateUnitTestTables()
+    protected function migrateUnitTestTables(): void
     {
         $this->loadMigrationsFrom([
             '--realpath' => realpath(__DIR__ . '/database/migrations'),
@@ -103,7 +102,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    protected function migratePackageTables()
+    protected function migratePackageTables(): void
     {
         $this->loadMigrationsFrom([
             '--realpath' => database_path('migrations'),
@@ -115,7 +114,7 @@ abstract class TestCase extends Orchestra
      *
      * @return void
      */
-    private function registerPackageFactories()
+    private function registerPackageFactories(): void
     {
         $pathToFactories = realpath(__DIR__ . '/database/factories');
         $this->withFactories($pathToFactories);
@@ -124,11 +123,11 @@ abstract class TestCase extends Orchestra
     /**
      * Set default user model used by tests.
      *
-     * @param $app
+     * @param \Illuminate\Foundation\Application $app
      * @return void
      */
-    private function setDefaultUserModel($app)
+    private function setDefaultUserModel($app): void
     {
-        $app['config']->set('auth.providers.users.model', User::class);
+        $app->make('config')->set('auth.providers.users.model', User::class);
     }
 }

--- a/tests/Unit/Events/ModelWasBannedTest.php
+++ b/tests/Unit/Events/ModelWasBannedTest.php
@@ -9,21 +9,18 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Events;
 
 use Cog\Laravel\Ban\Events\ModelWasBanned;
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Cog\Tests\Laravel\Ban\TestCase;
 
-/**
- * Class ModelWasBannedTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Events
- */
 class ModelWasBannedTest extends TestCase
 {
     /** @test */
-    public function it_can_fire_event_on_helper_call()
+    public function it_can_fire_event_on_helper_call(): void
     {
         $this->expectsEvents(ModelWasBanned::class);
 
@@ -33,7 +30,7 @@ class ModelWasBannedTest extends TestCase
     }
 
     /** @test */
-    public function it_can_fire_event_on_relation_create()
+    public function it_can_fire_event_on_relation_create(): void
     {
         $this->expectsEvents(ModelWasBanned::class);
 

--- a/tests/Unit/Events/ModelWasUnbannedTest.php
+++ b/tests/Unit/Events/ModelWasUnbannedTest.php
@@ -9,21 +9,18 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Events;
 
 use Cog\Laravel\Ban\Events\ModelWasUnbanned;
 use Cog\Laravel\Ban\Models\Ban;
 use Cog\Tests\Laravel\Ban\TestCase;
 
-/**
- * Class ModelWasUnbannedTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Events
- */
 class ModelWasUnbannedTest extends TestCase
 {
     /** @test */
-    public function it_can_fire_event_on_helper_call()
+    public function it_can_fire_event_on_helper_call(): void
     {
         $this->expectsEvents(ModelWasUnbanned::class);
 
@@ -32,7 +29,7 @@ class ModelWasUnbannedTest extends TestCase
     }
 
     /** @test */
-    public function it_can_fire_event_on_relation_delete()
+    public function it_can_fire_event_on_relation_delete(): void
     {
         $this->expectsEvents(ModelWasUnbanned::class);
 

--- a/tests/Unit/Models/BanTest.php
+++ b/tests/Unit/Models/BanTest.php
@@ -9,22 +9,19 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Models;
 
-use Carbon\Carbon;
 use Cog\Laravel\Ban\Models\Ban;
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Cog\Tests\Laravel\Ban\TestCase;
+use Illuminate\Support\Carbon;
 
-/**
- * Class BanTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Models
- */
 class BanTest extends TestCase
 {
     /** @test */
-    public function it_can_fill_comment()
+    public function it_can_fill_comment(): void
     {
         $ban = new Ban([
             'comment' => 'Enjoy your ban!',
@@ -34,7 +31,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_can_fill_expired_at()
+    public function it_can_fill_expired_at(): void
     {
         $expiredAt = Carbon::now()->toDateTimeString();
 
@@ -42,41 +39,41 @@ class BanTest extends TestCase
             'expired_at' => $expiredAt,
         ]);
 
-        $this->assertEquals($expiredAt, $ban->expired_at);
+        $this->assertEquals($expiredAt, $ban->getAttribute('expired_at'));
     }
 
     /** @test */
-    public function it_can_fill_created_by_type()
+    public function it_can_fill_created_by_type(): void
     {
         $ban = new Ban([
             'created_by_type' => 'TestType',
         ]);
 
-        $this->assertSame('TestType', $ban->created_by_type);
+        $this->assertSame('TestType', $ban->getAttribute('created_by_type'));
     }
 
     /** @test */
-    public function it_can_fill_created_by_id()
+    public function it_can_fill_created_by_id(): void
     {
         $ban = new Ban([
             'created_by_id' => '4',
         ]);
 
-        $this->assertSame('4', $ban->created_by_id);
+        $this->assertSame('4', $ban->getAttribute('created_by_id'));
     }
 
     /** @test */
-    public function it_casts_expired_at()
+    public function it_casts_expired_at(): void
     {
         $ban = new Ban([
             'expired_at' => '2018-03-28 00:00:00',
         ]);
 
-        $this->assertInstanceOf(Carbon::class, $ban->expired_at);
+        $this->assertInstanceOf(Carbon::class, $ban->getAttribute('expired_at'));
     }
 
     /** @test */
-    public function it_casts_deleted_at()
+    public function it_casts_deleted_at(): void
     {
         $ban = factory(Ban::class)->create([
             'deleted_at' => '2018-03-28 00:00:00',
@@ -86,17 +83,17 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_not_modify_null_expired_at()
+    public function it_not_modify_null_expired_at(): void
     {
         $ban = new Ban([
             'expired_at' => null,
         ]);
 
-        $this->assertNull($ban->expired_at);
+        $this->assertNull($ban->getAttribute('expired_at'));
     }
 
     /** @test */
-    public function it_can_has_ban_creator()
+    public function it_can_has_ban_creator(): void
     {
         $bannedBy = factory(User::class)->create();
 
@@ -109,7 +106,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_can_set_custom_ban_creator()
+    public function it_can_set_custom_ban_creator(): void
     {
         $bannable = factory(User::class)->create();
         $bannedBy = factory(User::class)->create();
@@ -123,7 +120,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_not_overwrite_ban_creator_with_auth_user_if_custom_value_is_provided()
+    public function it_not_overwrite_ban_creator_with_auth_user_if_custom_value_is_provided(): void
     {
         $bannable = factory(User::class)->create();
         $bannedBy = factory(User::class)->create();
@@ -140,7 +137,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_can_make_model_with_expire_carbon_date()
+    public function it_can_make_model_with_expire_carbon_date(): void
     {
         $expiredAt = Carbon::now();
 
@@ -148,32 +145,35 @@ class BanTest extends TestCase
             'expired_at' => $expiredAt,
         ]);
 
-        $this->assertEquals($expiredAt, $ban->expired_at);
+        $this->assertEquals($expiredAt, $ban->getAttribute('expired_at'));
     }
 
     /** @test */
-    public function it_can_make_model_with_expire_string_date()
+    public function it_can_make_model_with_expire_string_date(): void
     {
         $ban = new Ban([
             'expired_at' => '2086-03-28 00:00:00',
         ]);
 
-        $this->assertEquals('2086-03-28 00:00:00', $ban->expired_at);
+        $this->assertEquals('2086-03-28 00:00:00', $ban->getAttribute('expired_at'));
     }
 
     /** @test */
-    public function it_can_make_model_with_expire_relative_date()
+    public function it_can_make_model_with_expire_relative_date(): void
     {
         $ban = new Ban([
             'expired_at' => '+1 year',
         ]);
 
-        // TODO: Mock and check that \Carbon\Carbon::parse() method is called
-        $this->assertEquals(Carbon::parse('+1 year')->format('Y'), $ban->expired_at->format('Y'));
+        // TODO: Mock and check that \Illuminate\Support\Carbon::parse() method is called
+        $this->assertSame(
+            Carbon::parse('+1 year')->format('Y'),
+            $ban->getAttribute('expired_at')->format('Y')
+        );
     }
 
     /** @test */
-    public function it_can_has_bannable_model()
+    public function it_can_has_bannable_model(): void
     {
         $user = factory(User::class)->create();
 
@@ -186,7 +186,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_can_scope_bannable_models()
+    public function it_can_scope_bannable_models(): void
     {
         $user1 = factory(User::class)->create();
         factory(Ban::class, 4)->create([
@@ -205,7 +205,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_if_ban_is_permanent()
+    public function it_can_check_if_ban_is_permanent(): void
     {
         $permanentBan = new Ban();
         $temporaryBan = new Ban([
@@ -217,7 +217,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_if_ban_is_temporary()
+    public function it_can_check_if_ban_is_temporary(): void
     {
         $permanentBan = new Ban();
         $temporaryBan = new Ban([
@@ -229,7 +229,7 @@ class BanTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_if_ban_with_null_expired_at_is_permanent()
+    public function it_can_check_if_ban_with_null_expired_at_is_permanent(): void
     {
         $permanentBan = new Ban([
             'expired_at' => null,

--- a/tests/Unit/Observers/BanObserverTest.php
+++ b/tests/Unit/Observers/BanObserverTest.php
@@ -9,20 +9,17 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Observers;
 
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Cog\Tests\Laravel\Ban\TestCase;
 
-/**
- * Class BanObserverTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Observers
- */
 class BanObserverTest extends TestCase
 {
     /** @test */
-    public function it_can_set_banned_flag_to_owner_model_on_create()
+    public function it_can_set_banned_flag_to_owner_model_on_create(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,

--- a/tests/Unit/Scopes/BannedAtScopeTest.php
+++ b/tests/Unit/Scopes/BannedAtScopeTest.php
@@ -9,22 +9,19 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Scopes;
 
-use Carbon\Carbon;
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Cog\Tests\Laravel\Ban\Stubs\Models\UserWithBannedAtScopeApplied;
 use Cog\Tests\Laravel\Ban\TestCase;
+use Illuminate\Support\Carbon;
 
-/**
- * Class BannedAtScopeTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Scopes
- */
 class BannedAtScopeTest extends TestCase
 {
     /** @test */
-    public function it_can_get_all_models_by_default()
+    public function it_can_get_all_models_by_default(): void
     {
         factory(User::class, 2)->create([
             'banned_at' => Carbon::now()->subDay(),
@@ -40,7 +37,7 @@ class BannedAtScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_models_without_banned()
+    public function it_can_get_models_without_banned(): void
     {
         factory(User::class, 2)->create([
             'banned_at' => Carbon::now()->subDay(),
@@ -55,7 +52,7 @@ class BannedAtScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_models_with_banned()
+    public function it_can_get_models_with_banned(): void
     {
         factory(User::class, 2)->create([
             'banned_at' => Carbon::now()->subDay(),
@@ -70,7 +67,7 @@ class BannedAtScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_only_banned_models()
+    public function it_can_get_only_banned_models(): void
     {
         factory(User::class, 2)->create([
             'banned_at' => Carbon::now()->subDay(),
@@ -85,7 +82,7 @@ class BannedAtScopeTest extends TestCase
     }
 
     /** @test */
-    public function it_can_auto_apply_banned_at_default_scope()
+    public function it_can_auto_apply_banned_at_default_scope(): void
     {
         factory(User::class, 3)->create([
             'banned_at' => Carbon::now()->subDay(),

--- a/tests/Unit/Services/BanServiceTest.php
+++ b/tests/Unit/Services/BanServiceTest.php
@@ -9,22 +9,19 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Services;
 
-use Carbon\Carbon;
 use Cog\Laravel\Ban\Models\Ban;
 use Cog\Laravel\Ban\Services\BanService;
 use Cog\Tests\Laravel\Ban\TestCase;
+use Illuminate\Support\Carbon;
 
-/**
- * Class BanServiceTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Services
- */
 class BanServiceTest extends TestCase
 {
     /** @test */
-    public function it_can_delete_all_expired_bans()
+    public function it_can_delete_all_expired_bans(): void
     {
         factory(Ban::class, 3)->create([
             'expired_at' => Carbon::now()->subMonth(),

--- a/tests/Unit/Traits/BannableTest.php
+++ b/tests/Unit/Traits/BannableTest.php
@@ -9,23 +9,20 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Traits;
 
-use Carbon\Carbon;
 use Cog\Laravel\Ban\Models\Ban;
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Cog\Tests\Laravel\Ban\Stubs\Models\UserWithBannedAtScopeApplied;
 use Cog\Tests\Laravel\Ban\TestCase;
+use Illuminate\Support\Carbon;
 
-/**
- * Class BannableTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Traits
- */
 class BannableTest extends TestCase
 {
     /** @test */
-    public function it_can_has_related_ban()
+    public function it_can_has_related_ban(): void
     {
         $user = factory(User::class)->create();
 
@@ -35,12 +32,11 @@ class BannableTest extends TestCase
         ]);
 
         $assertBan = $user->bans->first();
-        $this->assertInstanceOf(Ban::class, $assertBan);
-        $this->assertEquals($ban->getKey(), $assertBan->getKey());
+        $this->assertTrue($ban->is($assertBan));
     }
 
     /** @test */
-    public function it_can_has_many_related_bans()
+    public function it_can_has_many_related_bans(): void
     {
         $user = factory(User::class)->create();
 
@@ -53,7 +49,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_ban()
+    public function it_can_ban(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,
@@ -66,7 +62,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_unban()
+    public function it_can_unban(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => Carbon::now(),
@@ -83,7 +79,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_ban_user_with_banned_at_scope_applied()
+    public function it_can_ban_user_with_banned_at_scope_applied(): void
     {
         $user = factory(UserWithBannedAtScopeApplied::class)->create([
             'banned_at' => Carbon::now(),
@@ -97,7 +93,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_unban_user_with_banned_at_scope_applied()
+    public function it_can_unban_user_with_banned_at_scope_applied(): void
     {
         $user = factory(UserWithBannedAtScopeApplied::class)->create([
             'banned_at' => Carbon::now(),
@@ -114,7 +110,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_delete_ban_on_unban()
+    public function it_can_delete_ban_on_unban(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => Carbon::now(),
@@ -131,7 +127,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_soft_delete_ban_on_unban()
+    public function it_can_soft_delete_ban_on_unban(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => Carbon::now(),
@@ -148,7 +144,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_return_ban_model()
+    public function it_can_return_ban_model(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,
@@ -160,7 +156,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_has_empty_banned_by()
+    public function it_can_has_empty_banned_by(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,
@@ -172,7 +168,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_has_current_user_as_banned_by()
+    public function it_can_has_current_user_as_banned_by(): void
     {
         $bannedBy = factory(User::class)->create();
         $user = factory(User::class)->create([
@@ -182,12 +178,11 @@ class BannableTest extends TestCase
 
         $ban = $user->ban();
 
-        $this->assertInstanceOf(User::class, $ban->createdBy);
-        $this->assertEquals($bannedBy->getKey(), $ban->createdBy->getKey());
+        $this->assertTrue($bannedBy->is($ban->createdBy));
     }
 
     /** @test */
-    public function it_can_ban_via_ban_relation_create()
+    public function it_can_ban_via_ban_relation_create(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,
@@ -204,7 +199,7 @@ class BannableTest extends TestCase
     }
 
     /** @test */
-    public function it_can_ban_with_comment()
+    public function it_can_ban_with_comment(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,
@@ -214,11 +209,11 @@ class BannableTest extends TestCase
             'comment' => 'Enjoy your ban',
         ]);
 
-        $this->assertEquals('Enjoy your ban', $ban->comment);
+        $this->assertSame('Enjoy your ban', $ban->comment);
     }
 
     /** @test */
-    public function it_can_ban_with_expiration_date()
+    public function it_can_ban_with_expiration_date(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,

--- a/tests/Unit/Traits/HasBannedAtHelpersTest.php
+++ b/tests/Unit/Traits/HasBannedAtHelpersTest.php
@@ -9,21 +9,18 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace Cog\Tests\Laravel\Ban\Unit\Traits;
 
-use Carbon\Carbon;
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Cog\Tests\Laravel\Ban\TestCase;
+use Illuminate\Support\Carbon;
 
-/**
- * Class HasBannedAtHelpersTest.
- *
- * @package Cog\Tests\Laravel\Ban\Unit\Traits
- */
 class HasBannedAtHelpersTest extends TestCase
 {
     /** @test */
-    public function it_can_set_banned_flag()
+    public function it_can_set_banned_flag(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,
@@ -35,7 +32,7 @@ class HasBannedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_unset_banned_flag()
+    public function it_can_unset_banned_flag(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => Carbon::now(),
@@ -47,7 +44,7 @@ class HasBannedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_if_entity_banned()
+    public function it_can_check_if_entity_banned(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => Carbon::now(),
@@ -57,7 +54,7 @@ class HasBannedAtHelpersTest extends TestCase
     }
 
     /** @test */
-    public function it_can_check_if_entity_not_banned()
+    public function it_can_check_if_entity_not_banned(): void
     {
         $user = factory(User::class)->create([
             'banned_at' => null,

--- a/tests/database/factories/BanFactory.php
+++ b/tests/database/factories/BanFactory.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Cog\Laravel\Ban\Models\Ban;
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Faker\Generator as Faker;

--- a/tests/database/factories/UserFactory.php
+++ b/tests/database/factories/UserFactory.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Cog\Tests\Laravel\Ban\Stubs\Models\User;
 use Cog\Tests\Laravel\Ban\Stubs\Models\UserWithBannedAtScopeApplied;
 use Faker\Generator as Faker;

--- a/tests/database/migrations/2016_09_02_173301_create_user_table.php
+++ b/tests/database/migrations/2016_09_02_173301_create_user_table.php
@@ -9,13 +9,12 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * Class CreateUserTable.
- */
 class CreateUserTable extends Migration
 {
     /**
@@ -23,7 +22,7 @@ class CreateUserTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
@@ -38,7 +37,7 @@ class CreateUserTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('users');
     }


### PR DESCRIPTION
- [x] deprecate all Laravel versions lower than 5.5
- [x] add Laravel 5.8 support
- [x] add strict types

To minimize upgrade process all namespaces & database structure will be untouched until v5.