### PR TITLE
Add ability to ignore default migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `cybercog/laravel-ban` will be documented in this file.
 
 ## [Unreleased]
 
+## [4.2.0] - 2019-09-26
+
 ### Added
 
 - ([#50]) Added publishable configuration file
@@ -123,7 +125,8 @@ All notable changes to `cybercog/laravel-ban` will be documented in this file.
 
 - Initial release
 
-[Unreleased]: https://github.com/cybercog/laravel-ban/compare/4.1.0...master
+[Unreleased]: https://github.com/cybercog/laravel-ban/compare/4.2.0...master
+[4.2.0]: https://github.com/cybercog/laravel-ban/compare/4.1.0...4.2.0
 [4.1.0]: https://github.com/cybercog/laravel-ban/compare/4.0.0...4.1.0
 [4.0.0]: https://github.com/cybercog/laravel-ban/compare/3.5.0...4.0.0
 [3.5.0]: https://github.com/cybercog/laravel-ban/compare/3.4.0...3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to `cybercog/laravel-ban` will be documented in this file.
 
 ### Added
 
-- Added publishable configuration file
-- Added ability to ignore default migrations
+- ([#50]) Added publishable configuration file
+- ([#50]) Added ability to ignore default migrations
 
 ## [4.1.0] - 2019-09-04
 
@@ -136,6 +136,7 @@ All notable changes to `cybercog/laravel-ban` will be documented in this file.
 [2.0.1]: https://github.com/cybercog/laravel-ban/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/cybercog/laravel-ban/compare/1.0.0...2.0.0
 
+[#50]: https://github.com/cybercog/laravel-ban/pull/50
 [#48]: https://github.com/cybercog/laravel-ban/pull/48
 [#35]: https://github.com/cybercog/laravel-ban/pull/35
 [#30]: https://github.com/cybercog/laravel-ban/pull/30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `cybercog/laravel-ban` will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Added publishable configuration file
+- Added ability to ignore default migrations
+
 ## [4.1.0] - 2019-09-04
 
 ### Added

--- a/config/ban.php
+++ b/config/ban.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Laravel Ban.
+ *
+ * (c) Anton Komarev <anton@komarev.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Ban Database Migrations
+    |--------------------------------------------------------------------------
+    |
+    | Determine if default package migrations should be registered.
+    | Set value to `false` when using customized migrations.
+    |
+    */
+
+    'load_default_migrations' => true,
+
+];


### PR DESCRIPTION
Added ability to ignore default migrations. It could be important when you already published migrations to custom directory for manual execution and want to ignore packaged ones.

Just publish config file with `php artisan vendor:publish --tag=ban-config` and change boolean flag `load_default_migrations` to `false`.