### PR TITLE
Add Laravel Temp Tag as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,7 @@ If you discover any security related issues, please email open@cybercog.su inste
 [Laravel Ban contributors list](../../contributors)
 
 ## Alternatives
-
-*Feel free to add more alternatives as Pull Request.* 
+https://github.com/imanghafoori1/laravel-temp-tag
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ If you discover any security related issues, please email open@cybercog.su inste
 [Laravel Ban contributors list](../../contributors)
 
 ## Alternatives
-https://github.com/imanghafoori1/laravel-temp-tag
+- https://github.com/imanghafoori1/laravel-temp-tag
 
 ## License
 


### PR DESCRIPTION
I think the temp-tag package has enough features to be considered as a more multi-purpose and less opinionated alternative for laravel-ban.
- It can have "comment" and "banned_by" in the tag payload.
- Tags expire like the ban period.
- It is possible to tag any model like it is to ban any model.
- There is a cache layer below to avoid joins when checking for tag existence.
- it is possible to filter out banned users when querying: `User::hasNotActiveTag('banned')->get();`

The only thing that has to be hand-coded is the middleware.