### PR TITLE
Add JSON response for blocked account login

### DIFF
--- a/src/Http/Middleware/ForbidBannedUser.php
+++ b/src/Http/Middleware/ForbidBannedUser.php
@@ -53,6 +53,10 @@ class ForbidBannedUser
                 'login' => 'This account is blocked.',
             ];
 
+            if ($request->expectsJson()) {
+                abort(403, $errors['login']);
+            }
+
             $responseCode = $request->header('X-Inertia') ? 303 : 302;
             if ($redirectUrl === null) {
                 return redirect()->back($responseCode)->withInput()->withErrors($errors);

--- a/src/Http/Middleware/LogsOutBannedUser.php
+++ b/src/Http/Middleware/LogsOutBannedUser.php
@@ -59,6 +59,10 @@ class LogsOutBannedUser
                 'login' => 'This account is blocked.',
             ];
 
+            if ($request->expectsJson()) {
+                abort(403, $errors['login']);
+            }
+
             $responseCode = $request->header('X-Inertia') ? 303 : 302;
             if ($redirectUrl === null) {
                 return redirect()->back($responseCode)->withInput()->withErrors($errors);


### PR DESCRIPTION
This pull request includes changes to the `handle` method in two middleware files, `ForbidBannedUser.php` and `LogsOutBannedUser.php`. The changes add a check for whether the request expects a JSON response, and if so, it aborts the request with a 403 status code and a message indicating that the account is blocked.

* [`src/Http/Middleware/ForbidBannedUser.php`](diffhunk://#diff-70718d4170aa88f44b04177f3fcef2e4f6009eab8b1693f4219eab858c018073R56-R59): Added a check to see if the request expects a JSON response. If it does, the request is aborted with a 403 status code and an error message.
* [`src/Http/Middleware/LogsOutBannedUser.php`](diffhunk://#diff-b30040641be175e231438febb5a18d03ed7249d183f705dd0f33a00a3d4756d5R62-R65): Similar to the change in `ForbidBannedUser.php`, a check was added to see if the request expects a JSON response. If it does, the request is aborted with a 403 status code and an error message.